### PR TITLE
Fix bug with checking of file/folder write permissions

### DIFF
--- a/inc/class-sc-config.php
+++ b/inc/class-sc-config.php
@@ -121,7 +121,8 @@ class SC_Config {
 	 * @return boolean
 	 */
 	private function _is_dir_writable( $dir ) {
-		$temp_handle = @fopen( untrailingslashit( $dir ) .  '/temp-write-test-' . time(), 'w' );
+		$temp_file_name = untrailingslashit( $dir ) .  '/temp-write-test-' . time();
+		$temp_handle = fopen( $temp_file_name, 'w' );
 
 		if ( $temp_handle ) {
 
@@ -130,12 +131,15 @@ class SC_Config {
 
 			if ( function_exists( 'fileowner' ) ) {
 				$wp_file_owner = @fileowner( __FILE__ );
+				// Pass in the temporary handle to determine the file owner.
 				$temp_file_owner = @fileowner( $temp_file_name );
 
+				// Close and remove the temporary file.
 				@fclose( $temp_handle );
-				@unlink( $temp_file_name );
+				@unlink( $temp_handle );
 
-				if ( $wp_file_owner !== false && $wp_file_owner === $temp_file_owner ) {
+				// Return if we cannot determine the file owner, or if the owner IDs do not match.
+				if ( $wp_file_owner === false || $wp_file_owner !== $temp_file_owner ) {
 					return false;
 				}
 			} else {

--- a/inc/class-sc-config.php
+++ b/inc/class-sc-config.php
@@ -135,8 +135,8 @@ class SC_Config {
 				$temp_file_owner = @fileowner( $temp_file_name );
 
 				// Close and remove the temporary file.
-				@fclose( $temp_handle );
-				@unlink( $temp_handle );
+				@fclose( $temp_file_name );
+				@unlink( $temp_file_name );
 
 				// Return if we cannot determine the file owner, or if the owner IDs do not match.
 				if ( $wp_file_owner === false || $wp_file_owner !== $temp_file_owner ) {


### PR DESCRIPTION
Hey @tlovett1 

I installed Simple Cache yesterday and immediately received the error relating to the plugin's inability to write to the config and the various folders.

I spent last night double checking my set-up, and in the end I was confident that everything was fine my end. For your reference and the benefit of anyone reading, I'm on a Ubuntu 14.04 Digital Ocean droplet running Nginx, HHVM and WordPress 4.5.2. All of my files and folders are chmod'ed correctly, and `www-data` owns all of the files which is correct given that Nginx runs as this user. Also, media uploads, Core and Plugin updates all work fine.

So, armed with the knowledge that everything was set-up correctly server side, I decided to have a poke around to see what the problem could be.

The first thing I did was add `return true` to the beginning of the `_is_dir_writable` function, and I immediately noticed that the plugin was able to write the `advanced-cache.php, `object-cache.php` etc...confirming that it wasn't permissions/ownership issue.

I ran several tests in a demo file in my web root, mimicking what `_is_dir_writable` and `verify_file_access` are trying to do in terms of writing to files/folders. All the tests were successful.

At this point I decided to start logging `WP_DEBUG` errors to file to see if the plugin was forthcoming...and I was in luck.

Each time I hit 'Try Again' to test the plugin's ability to write, the following errors were logged:
````
Notice: Undefined variable: temp_file_name in
 /var/www/davetgreen.me/wordpress/wp-content/plugins/simple-cache/inc/class-sc-config.php on line 133
Notice: Undefined variable: temp_file_name in
 /var/www/davetgreen.me/wordpress/wp-content/plugins/simple-cache/inc/class-sc-config.php on line 136
Warning: unlink(): No such file or directory in
 /var/www/davetgreen.me/wordpress/wp-content/plugins/simple-cache/inc/class-sc-config.php on line 136
````
Looking at the `_is_dir_writable` function I noticed that `$temp_file_name` isn't being defined, so I've introduced that and altered some of the logic accordingly.

This PR resolves the issues for me and the plugin works perfectly. This **might** be the cause of some user's issues that on the surface appear to be caused by their hosting? It could of course just be some bizarre esoteric thing and I am barking up the wrong tree completely! 😱 

Hope this is useful, and thanks for such a simple but powerful plugin! 😄 

Cheers,
Dave