### PR TITLE
replaced \r\n with PHP_EOL so that the system honors the OS's prefere…

### DIFF
--- a/inc/class-sc-advanced-cache.php
+++ b/inc/class-sc-advanced-cache.php
@@ -316,7 +316,7 @@ class SC_Advanced_Cache {
 			}
 		}
 
-		if ( ! $wp_filesystem->put_contents( $config_path, implode( "\n\r", $config_file ), FS_CHMOD_FILE ) ) {
+		if ( ! $wp_filesystem->put_contents( $config_path, implode( PHP_EOL, $config_file ), FS_CHMOD_FILE ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
…nce for line endings.

On several of my blogs, whenever I make a change that affects the wp-config, simple-cache adds a carriage return or newline to the beginning of each line. One of the sites affected is my podcast and this added errant CRFLs to the head of the XML feed making it invalid.

I replaced the "\r\n" with PHP_EOL in the implode so that it will use the same line endings that already exist.

Testing this on two of my sites, it does seem to work. (although I've not done exhaustive testing, I will admit)

Thanks for this great plugin.

Cheers!
=C=
