### PR TITLE
Fix: conditionally define FS_CHMOD_DIR and FS_CHMOD_FILE in sc_cache()

### DIFF
--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -25,6 +25,14 @@ function sc_cache( $buffer, $flags ) {
 		return $buffer;
 	}
 
+	// Set the permission constants if not already set.
+	// Normally, this is taken care of in WP_Filesystem constructor, but it is
+	// not invoked here, because WP_Filesystem_Direct is instantiated directly.
+	if ( ! defined('FS_CHMOD_DIR') )
+		define('FS_CHMOD_DIR', ( fileperms( ABSPATH ) & 0777 | 0755 ) );
+	if ( ! defined('FS_CHMOD_FILE') )
+		define('FS_CHMOD_FILE', ( fileperms( ABSPATH . 'index.php' ) & 0777 | 0644 ) );
+
 	include_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 	include_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 


### PR DESCRIPTION
Fixes #43.

I simply defined these constants the same way [WP_Filesystem](https://developer.wordpress.org/reference/functions/WP_Filesystem/) does when initialized.

Btw. I'm curious why are you not using WP_Filesystem here (which would inherently fix this issue). Is there any issue with using WP_Filesystem on frontend?