### PR TITLE
Fix: fclose() expects file handle, not filename.

### DIFF
--- a/inc/class-sc-config.php
+++ b/inc/class-sc-config.php
@@ -143,7 +143,7 @@ class SC_Config {
 				$temp_file_owner = @fileowner( $temp_file_name );
 
 				// Close and remove the temporary file.
-				@fclose( $temp_file_name );
+				@fclose( $temp_handle );
 				@unlink( $temp_file_name );
 
 				// Return if we cannot determine the file owner, or if the owner IDs do not match.


### PR DESCRIPTION
Hi,

As much as I would prefer #19 to be resolved by removing file owner check completely, I have a small fix to contribute here :-)