### PR TITLE
Remove needless calls to untrailingslashit().

### DIFF
--- a/inc/class-sc-advanced-cache.php
+++ b/inc/class-sc-advanced-cache.php
@@ -49,7 +49,7 @@ class SC_Advanced_Cache {
 		// File based caching only
 		if ( ! empty( $config['enable_page_caching'] ) && empty( $config['enable_in_memory_object_caching'] ) ) {
 			require_once( ABSPATH . 'wp-admin/includes/file.php');
-			
+
 			$comment = get_comment( $comment_ID );
 			$post_id = $comment->comment_post_ID;
 
@@ -59,7 +59,7 @@ class SC_Advanced_Cache {
 
 			$sub_path = preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
 
-			$path = untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache/' . preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
+			$path = WP_CONTENT_DIR . '/cache/simple-cache/' . preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
 
 			$wp_filesystem->delete( untrailingslashit( $path ) . '/index.html' );
 			$wp_filesystem->delete( untrailingslashit( $path ) . '/index.gzip.html' );
@@ -91,7 +91,7 @@ class SC_Advanced_Cache {
 
 			$sub_path = preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
 
-			$path = untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache/' . preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
+			$path = WP_CONTENT_DIR . '/cache/simple-cache/' . preg_replace( '#https?://#i', '', get_permalink( $post_id ) );
 
 			$wp_filesystem->delete( untrailingslashit( $path ) . '/index.html' );
 			$wp_filesystem->delete( untrailingslashit( $path ) . '/index.gzip.html' );
@@ -187,7 +187,7 @@ class SC_Advanced_Cache {
 
 		global $wp_filesystem;
 
-		$file = untrailingslashit( WP_CONTENT_DIR )  . '/advanced-cache.php';
+		$file = WP_CONTENT_DIR . '/advanced-cache.php';
 
 		$ret = true;
 
@@ -195,7 +195,7 @@ class SC_Advanced_Cache {
 			$ret = false;
 		}
 
-		$folder = untrailingslashit( WP_CONTENT_DIR )  . '/cache/simple-cache';
+		$folder = WP_CONTENT_DIR . '/cache/simple-cache';
 
 		if ( ! $wp_filesystem->delete( $folder, true ) ) {
 			$ret = false;
@@ -214,7 +214,7 @@ class SC_Advanced_Cache {
 
 		global $wp_filesystem;
 
-		$file = untrailingslashit( WP_CONTENT_DIR )  . '/advanced-cache.php';
+		$file = WP_CONTENT_DIR . '/advanced-cache.php';
 
 		$config = SC_Config::factory()->get();
 
@@ -234,7 +234,7 @@ class SC_Advanced_Cache {
 			"\n\r" . "if ( ! @file_exists( WP_CONTENT_DIR . '/sc-config/config-' . \$_SERVER['HTTP_HOST'] . '.php' ) ) { return; }" .
 			"\n\r" . "\$GLOBALS['sc_config'] = include( WP_CONTENT_DIR . '/sc-config/config-' . \$_SERVER['HTTP_HOST'] . '.php' );" .
 			"\n\r" . "if ( empty( \$GLOBALS['sc_config'] ) || empty( \$GLOBALS['sc_config']['enable_page_caching'] ) ) { return; }" .
-			"\n\r" . "if ( @file_exists( '" . untrailingslashit( plugin_dir_path( __FILE__ ) ) . '/dropins/' . $cache_file . "' ) ) { include_once( '" . untrailingslashit( plugin_dir_path( __FILE__ ) ) . '/dropins/' . $cache_file . "' ); }" . "\n\r";
+			"\n\r" . "if ( @file_exists( '" . dirname( __FILE__ ) . '/dropins/' . $cache_file . "' ) ) { include_once( '" . dirname( __FILE__ ) . '/dropins/' . $cache_file . "' ); }" . "\n\r";
 
 		}
 

--- a/inc/class-sc-config.php
+++ b/inc/class-sc-config.php
@@ -179,26 +179,26 @@ class SC_Config {
 		}
 
 		// Now check wp-content. We need to be able to create files of the same user as this file
-		if ( ! $this->_is_dir_writable( untrailingslashit( WP_CONTENT_DIR ) ) ) {
+		if ( ! $this->_is_dir_writable( WP_CONTENT_DIR ) ) {
 			return false;
 		}
 
 		// If the cache and/or cache/simple-cache directories exist, make sure it's writeable
-		if ( @file_exists( untrailingslashit( WP_CONTENT_DIR ) . '/cache' ) ) {
-			if ( ! $this->_is_dir_writable( untrailingslashit( WP_CONTENT_DIR ) . '/cache' ) ) {
+		if ( @file_exists( WP_CONTENT_DIR . '/cache' ) ) {
+			if ( ! $this->_is_dir_writable( WP_CONTENT_DIR . '/cache' ) ) {
 				return false;
 			}
 
-			if ( @file_exists( untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache' ) ) {
-				if ( ! $this->_is_dir_writable( untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache' ) ) {
+			if ( @file_exists( WP_CONTENT_DIR . '/cache/simple-cache' ) ) {
+				if ( ! $this->_is_dir_writable( WP_CONTENT_DIR . '/cache/simple-cache' ) ) {
 					return false;
 				}
 			}
 		}
 
 		// If the sc-config directory exists, make sure it's writeable
-		if ( @file_exists( untrailingslashit( WP_CONTENT_DIR ) . '/sc-config' ) ) {
-			if ( ! $this->_is_dir_writable( untrailingslashit( WP_CONTENT_DIR ) . '/sc-config' ) ) {
+		if ( @file_exists( WP_CONTENT_DIR . '/sc-config' ) ) {
+			if ( ! $this->_is_dir_writable( WP_CONTENT_DIR . '/sc-config' ) ) {
 				return false;
 			}
 		}
@@ -216,7 +216,7 @@ class SC_Config {
 
 		global $wp_filesystem;
 
-		$folder = untrailingslashit( WP_CONTENT_DIR )  . '/sc-config';
+		$folder = WP_CONTENT_DIR . '/sc-config';
 
 		delete_option( 'sc_simple_cache' );
 

--- a/inc/class-sc-object-cache.php
+++ b/inc/class-sc-object-cache.php
@@ -57,7 +57,7 @@ class SC_Object_Cache {
 
 		global $wp_filesystem;
 
-		$file = untrailingslashit( WP_CONTENT_DIR )  . '/object-cache.php';
+		$file = WP_CONTENT_DIR . '/object-cache.php';
 
 		if ( ! $wp_filesystem->delete( $file ) ) {
 			return false;
@@ -76,7 +76,7 @@ class SC_Object_Cache {
 
 		global $wp_filesystem;
 
-		$file = untrailingslashit( WP_CONTENT_DIR )  . '/object-cache.php';
+		$file = WP_CONTENT_DIR . '/object-cache.php';
 
 		$config = SC_Config::factory()->get();
 
@@ -95,7 +95,7 @@ class SC_Object_Cache {
 			"\n\r" . "if ( ! @file_exists( WP_CONTENT_DIR . '/sc-config/config-' . \$_SERVER['HTTP_HOST'] . '.php' ) ) { return; }" .
 			"\n\r" . "\$GLOBALS['sc_config'] = include( WP_CONTENT_DIR . '/sc-config/config-' . \$_SERVER['HTTP_HOST'] . '.php' );" .
 			"\n\r" . "if ( empty( \$GLOBALS['sc_config'] ) || empty( \$GLOBALS['sc_config']['enable_in_memory_object_caching'] ) ) { return; }" .
-			"\n\r" . "if ( @file_exists( '" . untrailingslashit( plugin_dir_path( __FILE__ ) ) . '/dropins/' . $cache_file . "' ) ) { require_once( '" . untrailingslashit( plugin_dir_path( __FILE__ ) ) . '/dropins/' . $cache_file . "' ); }" . "\n\r";
+			"\n\r" . "if ( @file_exists( '" . dirname( __FILE__ ) . '/dropins/' . $cache_file . "' ) ) { require_once( '" . dirname( __FILE__ ) . '/dropins/' . $cache_file . "' ); }" . "\n\r";
 
 		}
 

--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -31,15 +31,15 @@ function sc_cache( $buffer, $flags ) {
 	$filesystem = new WP_Filesystem_Direct( new StdClass() );
 
 	// Make sure we can read/write files and that proper folders exist
-	if ( ! $filesystem->exists( untrailingslashit( WP_CONTENT_DIR ) . '/cache' ) ) {
-		if ( ! $filesystem->mkdir( untrailingslashit( WP_CONTENT_DIR ) . '/cache' ) ) {
+	if ( ! $filesystem->exists( WP_CONTENT_DIR . '/cache' ) ) {
+		if ( ! $filesystem->mkdir( WP_CONTENT_DIR . '/cache' ) ) {
 			// Can not cache!
 			return $buffer;
 		}
 	}
 
-	if ( ! $filesystem->exists( untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache' ) ) {
-		if ( ! $filesystem->mkdir( untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache' ) ) {
+	if ( ! $filesystem->exists( WP_CONTENT_DIR . '/cache/simple-cache' ) ) {
+		if ( ! $filesystem->mkdir( WP_CONTENT_DIR . '/cache/simple-cache' ) ) {
 			// Can not cache!
 			return $buffer;
 		}
@@ -51,7 +51,7 @@ function sc_cache( $buffer, $flags ) {
 
 	$dirs = explode( '/', $url_path );
 
-	$path = untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache';
+	$path = WP_CONTENT_DIR . '/cache/simple-cache';
 
 	foreach ( $dirs as $dir ) {
 		if ( ! empty( $dir ) ) {
@@ -116,7 +116,7 @@ function sc_serve_cache() {
 		$file_name = 'index.gzip.html';
 	}
 
-	$path = rtrim( WP_CONTENT_DIR, '/' ) . '/cache/simple-cache/' . rtrim( sc_get_url_path(), '/' ) . '/' . $file_name;
+	$path = WP_CONTENT_DIR . '/cache/simple-cache/' . rtrim( sc_get_url_path(), '/' ) . '/' . $file_name;
 
 	$modified_time = (int) @filemtime( $path );
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -12,7 +12,7 @@ function sc_cache_flush() {
 
 	WP_Filesystem();
 
-	$wp_filesystem->rmdir( untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache', true );
+	$wp_filesystem->rmdir( WP_CONTENT_DIR . '/cache/simple-cache', true );
 
 	if ( function_exists( 'wp_cache_flush' ) ) {
 		wp_cache_flush();


### PR DESCRIPTION
Hi again,

I'm sorry for this avalanche of pull requests, but I really love your plugin, so I can't help improving it :-)

As for this PR:

1. [WP_CONTENT_DIR](https://core.trac.wordpress.org/browser/trunk/src/wp-includes/default-constants.php#L64) is defined without trailing slash and WP core consistently use it this way.
1. `untrailingslashit( plugin_dir_path( __FILE__ ) ) === dirname( __FILE__ )`, so why not use the latter? :-)

I know that using untrailingslashit does no harm, but I find the code harder to read...