### PR TITLE
Add admin check to setup_notice method

### DIFF
--- a/inc/class-sc-settings.php
+++ b/inc/class-sc-settings.php
@@ -50,6 +50,10 @@ class SC_Settings {
 	 * @since 1.0
 	 */
 	public function setup_notice() {
+		
+		if ( ! current_user_can('manage_options')) {
+	        return;
+        }
 
 		$cant_write = get_option( 'sc_cant_write', false );
 


### PR DESCRIPTION
Bails if current user is not an admin. Fixes #48 

