### PR TITLE
Only cache pages with a 200 status code

### DIFF
--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -21,7 +21,7 @@ function sc_cache( $buffer, $flags ) {
 	}
 
 	// Don't cache search, 404, or password protected
-	if ( is_404() || is_search() || post_password_required() ) {
+	if ( http_response_code() !== 200 || is_search() || post_password_required() ) {
 		return $buffer;
 	}
 


### PR DESCRIPTION
We are using a security plugin (WordFence) that sometimes limits access
to specific IP addresses by returning a page with a 'Status: 503
Service Temporarily Unavailable' code. The problem is that it seems
like this page is getting cached and then served to other users as well.