### PR TITLE
Prevent mixed content

### DIFF
--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -79,9 +79,11 @@ function sc_cache( $buffer, $flags ) {
 	$modified_time = time(); // Make sure modified time is consistent
 
 	// Prevent mixed content when there's an http request but the site URL uses https
-	if ( ! $_SERVER['HTTPS'] && 0 === ( strpos( get_option( 'siteurl' ), 'https' ) ) ) {
-		$http_site_url  = str_replace( 'https://', 'http://', get_option( 'siteurl' ) );
-		$buffer         = str_replace( $http_site_url, get_option( 'siteurl' ), $buffer );
+	$home_url = get_home_url();
+	if ( ! $_SERVER['HTTPS'] && 0 === ( strpos( $home_url, 'https' ) ) ) {
+		$https_home_url = $home_url;
+		$http_home_url  = str_replace( 'https://', 'http://', $https_home_url );
+		$buffer         = str_replace( esc_url( $http_home_url ), esc_url( $https_home_url ), $buffer );
 	}
 
 	if ( preg_match( '#</html>#i', $buffer ) ) {

--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -78,6 +78,12 @@ function sc_cache( $buffer, $flags ) {
 
 	$modified_time = time(); // Make sure modified time is consistent
 
+	// Prevent mixed content when there's an http request but the site URL uses https
+	if ( ! $_SERVER['HTTPS'] && 0 === ( strpos( get_option( 'siteurl' ), 'https' ) ) ) {
+		$http_site_url  = str_replace( 'https://', 'http://', get_option( 'siteurl' ) );
+		$buffer         = str_replace( $http_site_url, get_option( 'siteurl' ), $buffer );
+	}
+
 	if ( preg_match( '#</html>#i', $buffer ) ) {
 		$buffer .= "\n<!-- Cache served by Simple Cache - Last modified: " . gmdate( 'D, d M Y H:i:s', $modified_time ) . " GMT -->\n";
 	}

--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -80,7 +80,7 @@ function sc_cache( $buffer, $flags ) {
 
 	// Prevent mixed content when there's an http request but the site URL uses https
 	$home_url = get_home_url();
-	if ( ! $_SERVER['HTTPS'] && 0 === ( strpos( $home_url, 'https' ) ) ) {
+	if ( ! is_ssl() && 0 === ( strpos( $home_url, 'https' ) ) ) {
 		$https_home_url = $home_url;
 		$http_home_url  = str_replace( 'https://', 'http://', $https_home_url );
 		$buffer         = str_replace( esc_url( $http_home_url ), esc_url( $https_home_url ), $buffer );

--- a/inc/dropins/file-based-page-cache-functions.php
+++ b/inc/dropins/file-based-page-cache-functions.php
@@ -80,7 +80,7 @@ function sc_cache( $buffer, $flags ) {
 
 	// Prevent mixed content when there's an http request but the site URL uses https
 	$home_url = get_home_url();
-	if ( ! is_ssl() && 0 === ( strpos( $home_url, 'https' ) ) ) {
+	if ( ! is_ssl() && 'https' === strtolower( parse_url( $home_url, PHP_URL_SCHEME ) ) ) {
 		$https_home_url = $home_url;
 		$http_home_url  = str_replace( 'https://', 'http://', $https_home_url );
 		$buffer         = str_replace( esc_url( $http_home_url ), esc_url( $https_home_url ), $buffer );


### PR DESCRIPTION
When the site URL uses `https` and a request is done with `http`, this fix rewrites all occurrences of `siteurl` to use `https` in order to prevent mixed content.

Fixes #67.