### PR TITLE
Issue/63

### DIFF
--- a/inc/class-sc-advanced-cache.php
+++ b/inc/class-sc-advanced-cache.php
@@ -252,6 +252,12 @@ class SC_Advanced_Cache {
 
 		global $wp_filesystem;
 
+		// when calling from WP-CLI $wp_filesystem is not defined. If nothing
+		// is in $wp_filesystem then instatiate it.
+		if ( ! $wp_filesystem ) {
+			WP_Filesystem();
+		}
+
 		if ( defined( 'WP_CACHE' ) && WP_CACHE === $status ) {
 			return;
 		}

--- a/inc/class-sc-wp-cli.php
+++ b/inc/class-sc-wp-cli.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * The simple-cache-wp-cli.php file.
+ *
+ * Adds some WP-CLI commands to perform certain operations with the
+ * simple-cache plugin options.
+ */
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	return;
+}
+
+
+/**
+ * Implements example command.
+ */
+class Simple_Cache_WP_CLI extends WP_CLI_Command {
+
+	/**
+	 * Used to toggle either the cache or gzip compression options for
+	 * simple-cache to '1' - IE 'ON'.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--option=<option>]
+	 * : (optional) Option to toggle, either 'cache' or 'compression'.
+	 * ---
+	 * default: cache
+	 * options:
+	 *   - cache
+	 *   - compression
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp simple-cache on
+	 *     wp simple-cache on --option=compression
+	 *
+	 * @when before_wp_load
+	 */
+	function on( $args, $assoc_args ) {
+
+		// get the options array and assosiative args.
+		$sc_options = get_option( 'sc_simple_cache' );
+		$option = $assoc_args['option'];
+		// an empty string to start as a message.
+		$message = '';
+		switch ( $option ) {
+			case 'cache':
+				if ( 1 === $sc_options['enable_page_caching'] ) {
+					// cache is enabled aready set a message and do nothing.
+					$message = 'Cache already on';
+				} else {
+					// set the new value and update the options array.
+					$sc_options['enable_page_caching'] = 1;
+					$updated = update_option( 'sc_simple_cache', $sc_options );
+					SC_Advanced_Cache::factory()->toggle_caching( true );
+					$message = 'Cache toggled on';
+				}
+				break;
+
+			case 'compression':
+				if ( 1 === $sc_options['enable_gzip_compression'] ) {
+					// compression is enabled aready set a message and do nothing.
+					$message = 'Compression already on';
+				} else {
+					// set the new value and update the options array.
+					$sc_options['enable_gzip_compression'] = 1;
+					$updated = update_option( 'sc_simple_cache', $sc_options );
+					$message = 'Compression toggled on';
+				}
+
+				break;
+
+			default:
+		}
+		// if we have a successful $updated value then success... else error.
+		if ( isset( $updated ) && $updated ) {
+			WP_CLI::success( "$message" );
+		} else {
+			WP_CLI::error( "$message" );
+		}
+
+	}
+
+	/**
+	 * Used to toggle either the cache or gzip compression options for
+	 * simple-cache to '0' - IE 'OFF'.
+	 * ## OPTIONS
+	 *
+	 * [--option=<option>]
+	 * : (optional) Option to toggle, either 'cache' or 'compression'.
+	 * ---
+	 * default: cache
+	 * options:
+	 *   - cache
+	 *   - compression
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp simple-cache off
+	 *     wp simple-cache off --option=compression
+	 *
+	 * @when before_wp_load
+	 */
+	function off( $args, $assoc_args ) {
+
+		// get the options array and assosiative args.
+		$sc_options = get_option( 'sc_simple_cache' );
+		$option = $assoc_args['option'];
+		// an empty string to start as a message.
+		$message = '';
+		switch ( $option ) {
+			case 'cache':
+				if ( 0 === $sc_options['enable_page_caching'] ) {
+					// cache is disabled aready set a message and do nothing.
+					$message = 'Cache already off';
+				} else {
+					// set the new value and update the options array.
+					$sc_options['enable_page_caching'] = 0;
+					$updated = update_option( 'sc_simple_cache', $sc_options );
+					SC_Advanced_Cache::factory()->toggle_caching( false );
+					$message = 'Cache toggled off';
+				}
+				break;
+
+			case 'compression':
+				if ( 0 === $sc_options['enable_gzip_compression'] ) {
+					// compression is disabled aready set a message and do nothing.
+					$message = 'Compression already off';
+				} else {
+					// set the new value and update the options array.
+					$sc_options['enable_gzip_compression'] = 0;
+					$updated = update_option( 'sc_simple_cache', $sc_options );
+					$message = 'Compression toggled off';
+				}
+
+				break;
+
+			default:
+		}
+		// if we have a successful $updated value then success... else error.
+		if ( isset( $updated ) && $updated ) {
+			WP_CLI::success( "$message" );
+		} else {
+			WP_CLI::error( "$message" );
+		}
+	}
+}
+
+WP_CLI::add_command( 'simple-cache', 'Simple_Cache_WP_CLI' );

--- a/inc/class-sc-wp-cli.php
+++ b/inc/class-sc-wp-cli.php
@@ -1,9 +1,17 @@
 <?php
 /**
- * The simple-cache-wp-cli.php file.
+ * The class-sc-wp-cli.php file.
  *
  * Adds some WP-CLI commands to perform certain operations with the
- * simple-cache plugin options.
+ * simple-cache plugin options. Enable/disable caching at global level or
+ * enable/disable gzip compression. Default option to work with is 'cache'.
+ *
+ * wp wimple-cache on
+ * wp simple-cache off
+ * wp simple-cache on --option=compression
+ * wp simple-cache off --option=compression
+ * wp simple-cache on --option=cache
+ * wp simple-cache off --option=cache
  */
 
 if ( ! class_exists( 'WP_CLI' ) ) {
@@ -14,7 +22,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 /**
  * Implements example command.
  */
-class Simple_Cache_WP_CLI extends WP_CLI_Command {
+class SC_WP_CLI extends WP_CLI_Command {
 
 	/**
 	 * Used to toggle either the cache or gzip compression options for
@@ -149,4 +157,4 @@ class Simple_Cache_WP_CLI extends WP_CLI_Command {
 	}
 }
 
-WP_CLI::add_command( 'simple-cache', 'Simple_Cache_WP_CLI' );
+WP_CLI::add_command( 'simple-cache', 'SC_WP_CLI' );

--- a/simple-cache.php
+++ b/simple-cache.php
@@ -4,7 +4,7 @@
  * Plugin URI: http://taylorlovett.com
  * Description: A simple caching plugin that just works.
  * Author: Taylor Lovett
- * Version: 1.6.4
+ * Version: 1.6.3
  * Text Domain: simple-cache
  * Domain Path: /languages
  * Author URI: http://taylorlovett.com
@@ -12,7 +12,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SC_VERSION', '1.6.4' );
+define( 'SC_VERSION', '1.6.3' );
 
 require_once dirname( __FILE__ ) . '/inc/functions.php';
 require_once dirname( __FILE__ ) . '/inc/class-sc-settings.php';
@@ -20,6 +20,7 @@ require_once dirname( __FILE__ ) . '/inc/class-sc-config.php';
 require_once dirname( __FILE__ ) . '/inc/class-sc-advanced-cache.php';
 require_once dirname( __FILE__ ) . '/inc/class-sc-object-cache.php';
 require_once dirname( __FILE__ ) . '/inc/class-sc-cron.php';
+require_once dirname( __FILE__ ) . '/inc/class-sc-wp-cli.php';
 
 SC_Settings::factory();
 SC_Advanced_Cache::factory();
@@ -74,5 +75,3 @@ function sc_clean_up() {
 	SC_Config::factory()->clean_up();
 }
 register_deactivation_hook( __FILE__, 'sc_clean_up' );
-
-


### PR DESCRIPTION
Adds a set of simple commands for operating with simple-cache options. Current able to toggle caching on/off and gzip compression on/off using commands in this format:

* wp wimple-cache on
* wp simple-cache off
* wp simple-cache on --option=compression
* wp simple-cache off --option=compression
* wp simple-cache on --option=cache
* wp simple-cache off --option=cache

This is a starting point and could be refactored to make it more DRY and to accommodate all of the plugin options.