### PR TITLE
Adjust drop-down expiry units list position

### DIFF
--- a/assets/css/settings.css
+++ b/assets/css/settings.css
@@ -40,3 +40,6 @@
 
 #sc_cache_exception_urls {
   min-height: 120px; }
+
+#simple-cache table select {
+  vertical-align: unset; }

--- a/inc/class-sc-settings.php
+++ b/inc/class-sc-settings.php
@@ -250,7 +250,7 @@ class SC_Settings {
 		$config = SC_Config::factory()->get();
 
 		?>
-		<div class="wrap">
+		<div class="wrap" id="simple-cache">
 			<h1><?php esc_html_e( 'Simple Cache Settings', 'simple-cache' ); ?></h1>
 
 			<form action="" method="post">


### PR DESCRIPTION
These changes offer a more aligned position, and a nice and orderly view of the drop-down expiry units list.