### PR TITLE
Needs trailing slash after host

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -22,7 +22,7 @@ function sc_cache_flush( $network_wide = false ) {
 
 			$url_parts = wp_parse_url( home_url() );
 
-			$path = sc_get_cache_dir() . '/' . untrailingslashit( $url_parts['host'] );
+			$path = sc_get_cache_dir() . '/' . untrailingslashit( $url_parts['host'] ) . '/';
 
 			if ( ! empty( $url_parts['path'] ) && '/' !== $url_parts['path'] ) {
 				$path .= trim( $url_parts['path'], '/' );
@@ -35,7 +35,7 @@ function sc_cache_flush( $network_wide = false ) {
 	} else {
 		$url_parts = wp_parse_url( home_url() );
 
-		$path = sc_get_cache_dir() . '/' . untrailingslashit( $url_parts['host'] );
+		$path = sc_get_cache_dir() . '/' . untrailingslashit( $url_parts['host'] ) . '/';
 
 		if ( ! empty( $url_parts['path'] ) && '/' !== $url_parts['path'] ) {
 			$path .= trim( $url_parts['path'], '/' );

--- a/inc/pre-wp-functions.php
+++ b/inc/pre-wp-functions.php
@@ -115,6 +115,15 @@ function sc_get_url_path() {
 }
 
 /**
+ * Get URL path for caching
+ *
+ * @return string
+ */
+ function sc_get_cache_path() {
+	 return untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache';
+ }
+
+/**
  * Optionally serve cache and exit
  *
  * @since 1.0


### PR DESCRIPTION
Without the additional trailing slash, the cache directory can't be emptied because `$rm_path` is set to

```
wp-content/cache/simple-cache/example.comindex.html
``` 
instead of 

```
wp-content/cache/simple-cache/example.com/index.html
```