### PR TITLE
Implements sc_get_cache_path()

### DIFF
--- a/inc/pre-wp-functions.php
+++ b/inc/pre-wp-functions.php
@@ -129,6 +129,15 @@ function sc_get_url_path() {
 }
 
 /**
+ * Get URL path for caching
+ *
+ * @return string
+ */
+ function sc_get_cache_path() {
+	 return untrailingslashit( WP_CONTENT_DIR ) . '/cache/simple-cache';
+ }
+
+/**
  * Optionally serve cache and exit
  *
  * @since 1.0


### PR DESCRIPTION
which wasn't added when the call was introduced in 7423cc23ab0c7de952c5522760e98dc63518d896

I've added it to `inc/pre-wp-functions.php` because that's where your other `sc_get_` named functions live